### PR TITLE
Fix 404 messages

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,11 @@
++++
+title = "About"
+date = 2024-12-29
+author "NetworkChuck"
++++
+
+# Some header that sounds like it came from network chucck
+
+Text here describing the purpose of this blog as in the original video. Guessing Chuch would know how to word it better!
+
+Now your about page on your blog won't 404!

--- a/hugo.toml
+++ b/hugo.toml
@@ -11,7 +11,7 @@ paginate = 5
   contentTypeName = "posts"
 
   # if you set this to 0, only submenu trigger will be visible
-  showMenuItems = 2
+  showMenuItems = 1 # 2 if you have the showcase menu engaged
 
   # show selector to switch language
   showLanguageSelector = false
@@ -82,7 +82,7 @@ paginate = 5
           identifier = "about"
           name = "About"
           url = "/about"
-        [[languages.en.menu.main]]
-          identifier = "showcase"
-          name = "Showcase"
-          url = "/showcase"
+       # [[languages.en.menu.main]]
+        #  identifier = "showcase"
+        # name = "Showcase"
+        #  url = "/showcase"


### PR DESCRIPTION
I was browsing your site trying to figure out how the template worked and I was mortified to see that the site menu options 404ed. So I took it upon myself to fix those issues. you should be able to just test these changes by running `hugo server` on a clone of my fork and see if the about page shows up and the showcase page is gone but if you need any help feel free to let me know! Had no idea what to write for the about page but thought maybe the script for the blog video or some summary therein would probably be good!